### PR TITLE
Fix QR code not regenerating when switching documents

### DIFF
--- a/src/components/QRCodeSection.vue
+++ b/src/components/QRCodeSection.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { GristRecord } from '../types/document-schema'
 import { formatCurrency } from '../utils/currency'
 import { generatePromptPayQR } from '../utils/promptpay'
@@ -39,7 +39,8 @@ const showQR = computed(() => {
   return !!promptPayId.value
 })
 
-onMounted(async () => {
+const generateQRCode = async () => {
+  qrCodeUrl.value = null
   if (showQR.value && promptPayId.value) {
     try {
       qrCodeUrl.value = await generatePromptPayQR(promptPayId.value, viewModel.value.total)
@@ -47,7 +48,16 @@ onMounted(async () => {
       console.error('Failed to generate QR code:', error)
     }
   }
-})
+}
+
+onMounted(generateQRCode)
+
+watch(
+  () => [promptPayId.value, viewModel.value.total],
+  () => {
+    generateQRCode()
+  }
+)
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

Fixes issue #54 where the QR code was not regenerating when switching between documents. The QR code payload is now watched and regenerated whenever the PromptPay ID or amount changes.

## Changes

- Extracted QR code generation logic into a reusable `generateQRCode` async function
- Added a watcher that monitors both `promptPayId` and the total amount
- Clears the old QR code before generating a new one to show proper loading state
- Regenerates QR code on component mount and whenever payment data changes

## Testing

- Build passes without errors
- Type checking passes
- No console warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR code now automatically regenerates when payment ID or amount changes, instead of updating only on initial load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->