### PR TITLE
Allow Record field to be a JSON string that gets parsed

### DIFF
--- a/src/__tests__/document-schema.spec.ts
+++ b/src/__tests__/document-schema.spec.ts
@@ -63,4 +63,20 @@ describe('GristRecordSchema', () => {
 
     expect(result.success).toBe(false)
   })
+
+  it('parses Record when it is a JSON string', () => {
+    const objectRecord = createRecord('Receipt')
+    const stringRecord = { id: 1, Record: JSON.stringify(objectRecord.Record) }
+    const parsed = GristRecordSchema.parse(stringRecord)
+
+    expect(parsed.Record.Document_Type).toEqual(['Receipt'])
+    expect(parsed.Record.Number).toBe('TEST-001')
+    expect(parsed.Record.Items).toHaveLength(1)
+  })
+
+  it('rejects Record when it is an invalid JSON string', () => {
+    const result = GristRecordSchema.safeParse({ id: 1, Record: 'not valid json' })
+
+    expect(result.success).toBe(false)
+  })
 })

--- a/src/types/document-schema.ts
+++ b/src/types/document-schema.ts
@@ -61,7 +61,16 @@ export const RecordDataSchema = z.object({
 
 export const GristRecordSchema = z.object({
   id: z.number(),
-  Record: RecordDataSchema,
+  Record: z.preprocess((val) => {
+    if (typeof val === 'string') {
+      try {
+        return JSON.parse(val)
+      } catch {
+        return val
+      }
+    }
+    return val
+  }, RecordDataSchema),
 })
 
 // TypeScript types derived from Zod schemas


### PR DESCRIPTION
## Summary

- Allow `GristRecord.Record` field to accept either a `RecordData` object or a JSON string
- When a string is provided, it gets `JSON.parse`'d before Zod validation against `RecordDataSchema`
- Invalid JSON strings are rejected with a parse error from Zod
- Added unit tests for both string parsing and invalid JSON rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## บันทึกการเผยแพร่

* **New Features**
  * Record field ขณะนี้สามารถรับรองทั้งรูปแบบวัตถุและสตริง พร้อมการแยกวิเคราะห์ JSON อัตโนมัติสำหรับสตริงที่ถูกต้อง

* **Tests**
  * เพิ่มการทดสอบเพื่อตรวจสอบการวิเคราะห์ JSON ในการตรวจสอบความถูกต้องของ Record field

<!-- end of auto-generated comment: release notes by coderabbit.ai -->