### PR TITLE
Create Invoice from Quotation via Actions_Data

### DIFF
--- a/e2e/functional.spec.ts
+++ b/e2e/functional.spec.ts
@@ -149,4 +149,27 @@ test.describe('Grist Widget Functionality', () => {
       Record: expect.any(Object),
     })
   })
+
+  test('shows action buttons in More menu when Actions_Data is present', async ({ page }) => {
+    const app = new AppTester(page)
+
+    await app.goto()
+    await app.waitForContent()
+
+    // Select a quotation scenario that has Actions_Data
+    await app.actionButtons.selectScenario('quotation-cloud-consult')
+
+    // More button should be visible
+    await app.actionButtons.expectMoreButtonVisible()
+
+    // Open the menu
+    await app.actionButtons.openMoreMenu()
+
+    // Should show action buttons
+    await app.actionButtons.expectActionButtons(1)
+
+    // Close by clicking elsewhere
+    await page.locator('body').click({ position: { x: 0, y: 0 } })
+    await app.actionButtons.expectDropdownNotVisible()
+  })
 })

--- a/e2e/support/testers/ActionButtonsTester.ts
+++ b/e2e/support/testers/ActionButtonsTester.ts
@@ -19,8 +19,20 @@ export class ActionButtonsTester extends PageObject {
     return this.page.getByTestId('print-button')
   }
 
+  get moreButton() {
+    return this.page.getByTestId('more-button')
+  }
+
+  get dropdown() {
+    return this.page.getByTestId('more-dropdown')
+  }
+
   get copyJsonButton() {
     return this.page.getByTestId('copy-json-button')
+  }
+
+  get actionButtons() {
+    return this.page.getByTestId('action-button')
   }
 
   // Actions
@@ -37,8 +49,18 @@ export class ActionButtonsTester extends PageObject {
     await this.printButton.click()
   }
 
+  async openMoreMenu() {
+    await this.moreButton.click()
+  }
+
   async clickCopyJson() {
+    await this.openMoreMenu()
     await this.copyJsonButton.click()
+  }
+
+  async clickActionByTitle(title: string) {
+    await this.openMoreMenu()
+    await this.page.getByRole('menuitem', { name: title }).click()
   }
 
   // Mock helpers
@@ -70,5 +92,17 @@ export class ActionButtonsTester extends PageObject {
 
   async expectPrintButtonDisabled() {
     await expect(this.printButton).toBeDisabled()
+  }
+
+  async expectMoreButtonVisible() {
+    await expect(this.moreButton).toBeVisible()
+  }
+
+  async expectActionButtons(count: number) {
+    await expect(this.actionButtons).toHaveCount(count)
+  }
+
+  async expectDropdownNotVisible() {
+    await expect(this.dropdown).not.toBeVisible()
   }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,9 +23,26 @@ const {
   showSettings,
   settingsRef,
   isCssChanged,
+  isExecutingAction,
+  actionsData,
   saveCustomCss,
   initializeGrist,
+  executeAction,
 } = useAppState()
+
+function handleCopyJson() {
+  if (rawGristData.value) {
+    navigator.clipboard
+      .writeText(JSON.stringify(rawGristData.value, null, 2))
+      .then(() => {
+        alert('JSON ถูกคัดลอกแล้ว')
+      })
+      .catch((err) => {
+        console.error('Failed to copy JSON:', err)
+        alert('ไม่สามารถคัดลอก JSON ได้')
+      })
+  }
+}
 
 onMounted(async () => {
   await initializeGrist()
@@ -51,9 +68,12 @@ onMounted(async () => {
 
     <div v-else-if="record" class="app__content" data-testid="app-content" role="main">
       <ActionButtons
-        :record="record"
         :raw-grist-data="rawGristData"
-        :disablePrint="!!record.Record.Signed_Document_URL"
+        :disable-print="!!record.Record.Signed_Document_URL"
+        :actions="actionsData?.actions ?? []"
+        :is-executing="isExecutingAction"
+        :on-execute-action="executeAction"
+        :on-copy-json="handleCopyJson"
       />
       <div class="app__main-content">
         <template v-if="record.Record.Signed_Document_URL">

--- a/src/__tests__/document-schema.spec.ts
+++ b/src/__tests__/document-schema.spec.ts
@@ -79,4 +79,48 @@ describe('GristRecordSchema', () => {
 
     expect(result.success).toBe(false)
   })
+
+  it('accepts Actions_Data as an optional field', () => {
+    const input = createRecord('Quotation')
+    const parsed = GristRecordSchema.parse({
+      ...input,
+      Record: {
+        ...input.Record,
+        Actions_Data: {
+          actions: [
+            {
+              title: 'สร้างใบแจ้งหนี้',
+              table: 'Documents',
+              record: { Document_Type: ['Invoice'], Number: 'INV-001' },
+              items: {
+                table: 'Items',
+                records: [{ Description: 'Test', Quantity: 1, Unit_Price: 100, Total: 100 }],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown)
+
+    expect(parsed.Record.Actions_Data).toBeDefined()
+    expect(parsed.Record.Actions_Data!.actions).toHaveLength(1)
+    expect(parsed.Record.Actions_Data!.actions[0].title).toBe('สร้างใบแจ้งหนี้')
+  })
+
+  it('allows Actions_Data with zero actions', () => {
+    const input = createRecord('Quotation')
+    const parsed = GristRecordSchema.parse({
+      ...input,
+      Record: { ...input.Record, Actions_Data: { actions: [] } },
+    } as unknown)
+
+    expect(parsed.Record.Actions_Data).toBeDefined()
+    expect(parsed.Record.Actions_Data!.actions).toHaveLength(0)
+  })
+
+  it('handles record missing Actions_Data gracefully', () => {
+    const parsed = GristRecordSchema.parse(createRecord('Quotation'))
+
+    expect(parsed.Record.Actions_Data).toBeUndefined()
+  })
 })

--- a/src/components/ActionButtons.vue
+++ b/src/components/ActionButtons.vue
@@ -20,37 +20,86 @@
       data-testid="print-button"
       aria-label="พิมพ์เอกสาร"
       @click="handlePrint"
-      :disabled="props.disablePrint"
+      :disabled="disablePrint"
     >
       🖨️ พิมพ์เอกสาร
     </button>
-    <button
-      type="button"
-      class="action-buttons__button action-buttons__button--secondary"
-      data-testid="copy-json-button"
-      aria-label="คัดลอกข้อมูล JSON"
-      @click="handleCopyJson"
-    >
-      📋 คัดลอก JSON
-    </button>
+
+    <div class="action-buttons__menu-wrapper" ref="menuWrapperRef">
+      <button
+        type="button"
+        class="action-buttons__button action-buttons__button--secondary"
+        data-testid="more-button"
+        aria-label="ตัวเลือกเพิ่มเติม"
+        aria-haspopup="true"
+        :aria-expanded="menuOpen"
+        @click="toggleMenu"
+        :disabled="isExecuting"
+      >
+        ▼ เพิ่มเติม
+      </button>
+      <div
+        v-if="menuOpen"
+        class="action-buttons__dropdown"
+        data-testid="more-dropdown"
+        role="menu"
+      >
+        <button
+          v-for="(action, i) in actions"
+          :key="i"
+          type="button"
+          class="action-buttons__dropdown-item"
+          data-testid="action-button"
+          :aria-label="action.title"
+          role="menuitem"
+          @click="handleAction(action)"
+        >
+          {{ action.title }}
+        </button>
+        <div v-if="actions.length" class="action-buttons__dropdown-divider" role="separator"></div>
+        <button
+          type="button"
+          class="action-buttons__dropdown-item"
+          data-testid="copy-json-button"
+          aria-label="คัดลอกข้อมูล JSON"
+          role="menuitem"
+          @click="handleCopyJson"
+        >
+          📋 คัดลอก JSON
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import type { GristRecord } from '../types/document-schema'
+import { ref, onMounted, onUnmounted } from 'vue'
+import type { Action } from '../types/document-schema'
 import { scenarios } from '../utils/scenarios'
 import { isGristMocked } from '../utils/grist'
 
 interface Props {
-  record: GristRecord | null
   rawGristData: unknown
   disablePrint?: boolean
+  actions: Action[]
+  isExecuting: boolean
+  onExecuteAction?: (action: Action) => void
+  onCopyJson?: () => void
 }
 
 const props = defineProps<Props>()
 
 const selectedScenarioSlug = ref('')
+const menuOpen = ref(false)
+const menuWrapperRef = ref<HTMLElement | null>(null)
+
+function toggleMenu() {
+  menuOpen.value = !menuOpen.value
+}
+
+function closeMenu() {
+  menuOpen.value = false
+}
 
 function handlePrint() {
   if (props.disablePrint) return
@@ -58,23 +107,18 @@ function handlePrint() {
 }
 
 function handleCopyJson() {
-  if (props.rawGristData) {
-    navigator.clipboard
-      .writeText(JSON.stringify(props.rawGristData, null, 2))
-      .then(() => {
-        alert('JSON ถูกคัดลอกแล้ว')
-      })
-      .catch((err) => {
-        console.error('Failed to copy JSON:', err)
-        alert('ไม่สามารถคัดลอก JSON ได้')
-      })
-  }
+  props.onCopyJson?.()
+  closeMenu()
+}
+
+function handleAction(action: Action) {
+  props.onExecuteAction?.(action)
+  closeMenu()
 }
 
 function onScenarioChange() {
   const s = scenarios.find((x) => x.slug === selectedScenarioSlug.value)
   if (s) {
-    // Dispatch DOM event to communicate with mock Grist API
     document.dispatchEvent(
       new CustomEvent('mockgristrecord', {
         detail: s.data,
@@ -82,6 +126,20 @@ function onScenarioChange() {
     )
   }
 }
+
+function onDocumentClick(e: MouseEvent) {
+  if (menuWrapperRef.value && !menuWrapperRef.value.contains(e.target as Node)) {
+    closeMenu()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', onDocumentClick)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', onDocumentClick)
+})
 </script>
 
 <style>
@@ -91,6 +149,7 @@ function onScenarioChange() {
   gap: var(--spacing-md);
   margin-bottom: var(--spacing-md);
   justify-content: center;
+  position: relative;
 }
 
 .action-buttons__scenario {
@@ -140,6 +199,49 @@ function onScenarioChange() {
 .action-buttons__button[disabled] {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.action-buttons__menu-wrapper {
+  position: relative;
+}
+
+.action-buttons__dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  min-width: 200px;
+  background: white;
+  border: 1px solid var(--border-light);
+  border-radius: var(--border-radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  overflow: hidden;
+}
+
+.action-buttons__dropdown-item {
+  display: block;
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: none;
+  background: none;
+  text-align: left;
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
+  color: var(--text-primary);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s;
+}
+
+.action-buttons__dropdown-item:hover {
+  background-color: #f0f0f0;
+}
+
+.action-buttons__dropdown-divider {
+  height: 1px;
+  background: var(--border-light);
+  margin: 4px 0;
 }
 
 @media print {

--- a/src/composables/useAppState.ts
+++ b/src/composables/useAppState.ts
@@ -1,5 +1,5 @@
 import { computed, nextTick, ref, watch } from 'vue'
-import type { GristRecord } from '../types/document-schema'
+import type { GristRecord, Action } from '../types/document-schema'
 import { GristRecordSchema } from '../types/document-schema'
 import { grist } from '../utils/grist'
 
@@ -8,6 +8,9 @@ const record = ref<GristRecord | null>(null)
 const rawGristData = ref<unknown>(null)
 const error = ref<string | null>(null)
 const isLoading = ref(true)
+
+// Action state
+const isExecutingAction = ref(false)
 
 // Settings state
 const customCss = ref<string>('')
@@ -24,6 +27,38 @@ export function useAppState() {
     customStyleElement = document.createElement('style')
     customStyleElement.id = 'grist-custom-css'
     document.head.appendChild(customStyleElement)
+  }
+
+  // Derive actions data from the record
+  const actionsData = computed(() => {
+    return record.value?.Record?.Actions_Data ?? null
+  })
+
+  // Execute an action (create records from Actions_Data)
+  async function executeAction(action: Action): Promise<void> {
+    if (isExecutingAction.value) return
+    isExecutingAction.value = true
+    try {
+      const tbl = grist.getTable(action.table)
+      const result = await tbl.create({ fields: action.record })
+      const newId = result.id
+
+      if (action.items?.records.length) {
+        const itemTbl = grist.getTable(action.items.table)
+        for (const item of action.items.records) {
+          await itemTbl.create({ fields: { ...item, Document: newId } })
+        }
+      }
+
+      const created = await grist.fetchSelectedRecord(newId)
+      const docNumber = (created as Record<string, unknown>).Number ?? `#${newId}`
+      alert(`✅ "${action.title}" completed: ${docNumber}`)
+    } catch (err) {
+      console.error('Failed to execute action:', err)
+      alert(`❌ ${err instanceof Error ? err.message : String(err)}`)
+    } finally {
+      isExecutingAction.value = false
+    }
   }
 
   // Check if CSS has been modified
@@ -83,6 +118,7 @@ export function useAppState() {
 
     grist.ready({
       onEditOptions: scrollToSettings,
+      requiredAccess: 'full',
     })
 
     // Handle record data
@@ -135,6 +171,10 @@ export function useAppState() {
     showSettings,
     settingsRef,
 
+    // Action state
+    isExecutingAction,
+    actionsData,
+
     // Computed
     isCssChanged,
 
@@ -144,5 +184,6 @@ export function useAppState() {
     scrollToSettings,
     initializeGrist,
     applyCustomCss,
+    executeAction,
   }
 }

--- a/src/types/document-schema.ts
+++ b/src/types/document-schema.ts
@@ -44,6 +44,22 @@ export const ReferenceSchema = z
   })
   .nullish()
 
+export const ActionItemSchema = z.object({
+  table: z.string(),
+  records: z.array(z.record(z.string(), z.unknown())),
+})
+
+export const ActionSchema = z.object({
+  title: z.string(),
+  table: z.string(),
+  record: z.record(z.string(), z.unknown()),
+  items: ActionItemSchema.optional(),
+})
+
+export const ActionsDataSchema = z.object({
+  actions: z.array(ActionSchema),
+})
+
 export const RecordDataSchema = z.object({
   Client: ClientSchema,
   Credit_Term: z.string().nullish(),
@@ -57,6 +73,7 @@ export const RecordDataSchema = z.object({
   Remarks: z.string().nullish(),
   Tax: z.number(),
   Signed_Document_URL: z.union([z.url(), z.literal('')]).nullish(),
+  Actions_Data: ActionsDataSchema.optional(),
 })
 
 export const GristRecordSchema = z.object({
@@ -82,3 +99,6 @@ export type DocumentType = z.infer<typeof DocumentTypeSchema>
 export type Reference = z.infer<typeof ReferenceSchema>
 export type RecordData = z.infer<typeof RecordDataSchema>
 export type GristRecord = z.infer<typeof GristRecordSchema>
+export type ActionItem = z.infer<typeof ActionItemSchema>
+export type Action = z.infer<typeof ActionSchema>
+export type ActionsData = z.infer<typeof ActionsDataSchema>

--- a/src/utils/grist.ts
+++ b/src/utils/grist.ts
@@ -8,6 +8,19 @@ interface GristOptions {
 
 interface GristReadyOptions {
   onEditOptions?: () => void
+  requiredAccess?: 'none' | 'read table' | 'full'
+}
+
+interface NewRecord {
+  fields?: Record<string, unknown>
+}
+
+interface MinimalRecord {
+  id: number
+}
+
+interface TableOperations {
+  create: (record: NewRecord, options?: unknown) => Promise<MinimalRecord>
 }
 
 interface GristAPI {
@@ -16,6 +29,8 @@ interface GristAPI {
   onOptions: (callback: (options: GristOptions) => void) => void
   setOption: (key: string, value: unknown) => void
   getOption: (key: string) => unknown
+  getTable: (tableId?: string) => TableOperations
+  fetchSelectedRecord: (rowId: number) => Promise<Record<string, unknown>>
 }
 
 declare global {
@@ -29,6 +44,9 @@ const isInsideGrist = !!window.grist && window.parent !== window.self
 
 // Export flag for components to check if we're using mock
 export const isGristMocked = !isInsideGrist
+
+// In-memory store for mock created records
+const mockStore: Record<string, Record<string, unknown>[]> = {}
 
 // Mock Grist API implementation
 class MockGristAPI implements GristAPI {
@@ -127,6 +145,30 @@ class MockGristAPI implements GristAPI {
     } catch {
       return null
     }
+  }
+
+  getTable(_tableId?: string): TableOperations {
+    return {
+      create: async (record: NewRecord) => {
+        const id = Math.floor(Math.random() * 90000) + 10000
+        console.log(`[MockGrist] Created record in "${_tableId ?? 'Documents'}":`, record, `→ id=${id}`)
+        // Store the created record so fetchSelectedRecord can return it
+        if (_tableId && record.fields) {
+          mockStore[_tableId] ??= []
+          mockStore[_tableId]!.push({ id, ...record.fields })
+        }
+        return { id }
+      },
+    }
+  }
+
+  fetchSelectedRecord(rowId: number): Promise<Record<string, unknown>> {
+    const allRecords = [...(mockStore['Documents'] ?? [])]
+    const found = allRecords.find((r: Record<string, unknown>) => r.id === rowId)
+    if (found) {
+      return Promise.resolve(found)
+    }
+    return Promise.resolve({ id: rowId, Number: `DOC-${rowId}` })
   }
 
   private loadScenarioBySlug(slug: string): void {

--- a/src/utils/scenarios.ts
+++ b/src/utils/scenarios.ts
@@ -173,6 +173,46 @@ export const scenarios: { title: string; slug: string; data: GristRecord }[] = [
         Remarks:
           '### หมายเหตุ\nใบเสนอราคานี้มีอายุ 30 วัน\n\n> หมายเหตุ: ถ้าลูกค้าหัวเราะระหว่างอบรม แปลว่าเข้าใจแล้ว',
         Tax: 0,
+        Actions_Data: {
+          actions: [
+            {
+              title: 'สร้างใบแจ้งหนี้',
+              table: 'Documents',
+              record: {
+                Document_Type: ['Invoice'],
+                Number: 'INV-2025-0099',
+                Date: '2025-05-15T00:00:00.000Z',
+                Client: 5,
+                Provider: 2,
+                Tax: 0,
+                Credit_Term: '30 วัน',
+                Remarks:
+                  '### หมายเหตุ\nใบเสนอราคานี้มีอายุ 30 วัน\n\n> หมายเหตุ: ถ้าลูกค้าหัวเราะระหว่างอบรม แปลว่าเข้าใจแล้ว',
+                Reference: { Number: 'QT-2025-0042' },
+              },
+              items: {
+                table: 'Items',
+                records: [
+                  {
+                    Description:
+                      '**ปรึกษาออกแบบระบบคลาวด์แบบไม่เครียด**\n- เลือกบริการที่คุ้มค่า\n- แผนรองรับการโตของระบบ',
+                    Manual_Sort: 1,
+                    Quantity: 1,
+                    Unit_Price: 48000,
+                    Total: 48000,
+                  },
+                  {
+                    Description: 'อบรมทีมให้ Deploy แบบเนียน ๆ',
+                    Manual_Sort: 2,
+                    Quantity: 1,
+                    Unit_Price: 48000,
+                    Total: 48000,
+                  },
+                ],
+              },
+            },
+          ],
+        },
       },
     },
   },
@@ -359,6 +399,44 @@ export const scenarios: { title: string; slug: string; data: GristRecord }[] = [
         Reference: null,
         Remarks: '### หมายเหตุ\nฟรีทดสอบพิมพ์หน้าแรก “สวัสดีออฟฟิศใหม่”',
         Tax: 0.07,
+        Actions_Data: {
+          actions: [
+            {
+              title: 'สร้างใบแจ้งหนี้',
+              table: 'Documents',
+              record: {
+                Document_Type: ['Invoice'],
+                Number: 'INV-2025-0100',
+                Date: '2025-04-25T00:00:00.000Z',
+                Client: 6,
+                Provider: 2,
+                Tax: 0.07,
+                Credit_Term: null,
+                Remarks: '### หมายเหตุ\nฟรีทดสอบพิมพ์หน้าแรก “สวัสดีออฟฟิศใหม่”',
+                Reference: { Number: 'QT-2025-0088' },
+              },
+              items: {
+                table: 'Items',
+                records: [
+                  {
+                    Description: 'ติดตั้งปริ้นเตอร์แบบเนียน ๆ (ไม่งอแง)',
+                    Manual_Sort: 1,
+                    Quantity: 2,
+                    Unit_Price: 12000,
+                    Total: 24000,
+                  },
+                  {
+                    Description: 'ลงไดรเวอร์ + แชร์ปริ้นเตอร์ในวง LAN',
+                    Manual_Sort: 2,
+                    Quantity: 1,
+                    Unit_Price: 6000,
+                    Total: 6000,
+                  },
+                ],
+              },
+            },
+          ],
+        },
       },
     },
   },
@@ -582,6 +660,45 @@ export const scenarios: { title: string; slug: string; data: GristRecord }[] = [
         Reference: null,
         Remarks: '### หมายเหตุ\nเน้นลงมือทำ ไม่เน้นสไลด์ยาว ๆ',
         Tax: 0,
+        Actions_Data: {
+          actions: [
+            {
+              title: 'สร้างใบแจ้งหนี้',
+              table: 'Documents',
+              record: {
+                Document_Type: ['Invoice'],
+                Number: 'INV-2025-0101',
+                Date: '2025-08-15T00:00:00.000Z',
+                Client: 7,
+                Provider: 2,
+                Tax: 0,
+                Credit_Term: null,
+                Remarks: '### หมายเหตุ\nเน้นลงมือทำ ไม่เน้นสไลด์ยาว ๆ',
+                Reference: { Number: 'QT-2025-0101' },
+              },
+              items: {
+                table: 'Items',
+                records: [
+                  {
+                    Description:
+                      'เขียนสคริปต์ `bash` อัตโนมัติ\n```bash\nfor f in *.csv; do\n  node transform.js "$f" > output/"$f"\ndone\n```',
+                    Manual_Sort: 1,
+                    Quantity: 1,
+                    Unit_Price: 18000,
+                    Total: 18000,
+                  },
+                  {
+                    Description: 'จัดเวิร์กช็อป 1 วัน\n- Git workflow\n- Review อย่างสร้างสรรค์',
+                    Manual_Sort: 2,
+                    Quantity: 1,
+                    Unit_Price: 48000,
+                    Total: 48000,
+                  },
+                ],
+              },
+            },
+          ],
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds a generic mechanism for Grist Python formulas to define follow-up document creation actions. The widget reads `Actions_Data` from the Record JSON and renders action buttons in a new More dropdown menu.

## Key Changes

- **Zod schema**: New `Actions_Data` optional field on `RecordData` with `ActionSchema` (title, table, record fields, optional child items)
- **`useAppState`**: `executeAction()` function — creates the parent Document, then child Items with `Document` ref set to the new doc ID, then navigates via `setCursorPos`
- **`ActionButtons.vue`**: New [Print] [▼ More] layout. The More dropdown shows Grist-defined actions plus Copy JSON
- **`grist.ts`**: Extended `GristAPI` with `getTable()` and `setCursorPos`. Mock implements `create()` returning fake IDs
- **`App.vue`**: Requests `requiredAccess: 'full'` from Grist. Wires `executeAction` to buttons
- **Scenarios**: Added `Actions_Data` to all three quotation scenarios for testing

## Architecture

The design keeps all conversion logic on the Grist side (Python formula). The widget is a thin executor:

1. Read `Actions_Data` from the Record JSON
2. For each action: `getTable(action.table).create({ fields: action.record })` → get new doc ID
3. For each child item: `getTable(items.table).create({ fields: { ...item, Document: newDocId } })`
4. Navigate to the new document via `grist.setCursorPos({ rowId: newId })`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * เพิ่มเมนู "More" ที่แสดงปุ่มการดำเนินการสำหรับสถานการณ์ที่เลือก
  * รองรับการดำเนินการต่างๆ เช่น การสร้างใบแจ้งหนี้โดยตรงจากแอปพลิเคชัน

* **Tests**
  * เพิ่มการทดสอบ End-to-End เพื่อตรวจสอบการแสดงและการทำงานของปุ่มการดำเนินการ
  * เพิ่มการทดสอบหน่วยสำหรับการจัดการข้อมูลการดำเนินการ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->