### PR TITLE
Show combined receipt/VAT title when Receipt has VAT 7%

### DIFF
--- a/src/components/DocumentHeader.vue
+++ b/src/components/DocumentHeader.vue
@@ -26,7 +26,7 @@
 
     <div class="document-header__info">
       <h2 class="document-header__type">
-        {{ getDocumentTypeInThai(record.Record.Document_Type[0]) }}
+        {{ getDocumentTypeInThai(record.Record.Document_Type[0], hasVat) }}
       </h2>
       <div class="document-header__details">
         <div class="document-header__number">เลขที่: {{ record.Record.Number }}</div>
@@ -47,6 +47,7 @@ import { computed } from 'vue'
 import type { GristRecord } from '../types/document-schema'
 import { formatDate, getDocumentTypeInThai } from '../utils/document'
 import { getViewModel } from '../utils/view-model'
+import { isVatRate } from '../utils/tax'
 
 interface Props {
   record: GristRecord
@@ -57,6 +58,8 @@ const props = defineProps<Props>()
 const viewModel = computed(() => {
   return getViewModel(props.record)
 })
+
+const hasVat = computed(() => isVatRate(props.record.Record.Tax))
 
 function trimAddress(address: string): string {
   return address.trim()

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -8,14 +8,14 @@ export function sortItems(items: Item[]): Item[] {
   })
 }
 
-export function getDocumentTypeInThai(type: DocumentType): string {
+export function getDocumentTypeInThai(type: DocumentType, hasVat?: boolean): string {
   switch (type) {
     case 'Quotation':
       return 'ใบเสนอราคา'
     case 'Invoice':
       return 'ใบแจ้งหนี้'
     case 'Receipt':
-      return 'ใบเสร็จรับเงิน'
+      return hasVat ? 'ใบเสร็จรับเงิน / ใบกำกับภาษี' : 'ใบเสร็จรับเงิน'
     default:
       return type
   }

--- a/src/utils/tax.ts
+++ b/src/utils/tax.ts
@@ -5,11 +5,15 @@ export interface TaxInfo {
   displayAmount: string
 }
 
+export function isVatRate(taxPercentage: number): boolean {
+  return taxPercentage > 0 && Math.abs(taxPercentage - 0.07) < 0.001
+}
+
 export function getTaxInfo(taxPercentage: number, subtotal: number): TaxInfo {
   const taxAmount = subtotal * taxPercentage
 
   // Check for 7% VAT (with some tolerance for floating point)
-  if (taxPercentage > 0 && Math.abs(taxPercentage - 0.07) < 0.001) {
+  if (isVatRate(taxPercentage)) {
     return {
       label: 'VAT 7%',
       percentage: taxPercentage,


### PR DESCRIPTION
## Summary

When a Receipt document has VAT 7% (Tax ≈ 0.07), the document header now shows "ใบเสร็จรับเงิน / ใบกํากับภาษี" instead of the normal "ใบเสร็จรับเงิน".

### Changes

- **`src/utils/tax.ts`**: Extracted `isVatRate()` helper to centralize the 7% VAT detection logic
- **`src/utils/document.ts`**: Added optional `hasVat` parameter to `getDocumentTypeInThai()` — when true and type is Receipt, returns the combined title
- **`src/components/DocumentHeader.vue`**: Computes `hasVat` from the record's Tax field and passes it to `getDocumentTypeInThai()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * ป้ายกำกับประเภทเอกสารใบเสร็จรับเงินได้รับการปรับปรุงเพื่อแสดงข้อมูลสถานะภาษีมูลค่าเพิ่มได้อย่างถูกต้อง ระบบจะแยกแยะเอกสารที่มีภาษีและไม่มีภาษีได้ชัดเจนขึ้น ช่วยให้ผู้ใช้จัดการและติดตามเอกสารได้อย่างมีประสิทธิภาพ

<!-- end of auto-generated comment: release notes by coderabbit.ai -->